### PR TITLE
Document optional Celery/Temporal installs

### DIFF
--- a/.tasks/task-temporal-integration.md
+++ b/.tasks/task-temporal-integration.md
@@ -15,8 +15,7 @@ MEMO: This migration can be done incrementally, running both Celery and Temporal
 1. [ ] Install Temporal.io SDK dependencies
 
    ```sh
-   uv add temporalio asgiref
-   uv sync
+   pip install dj-triggers[temporal]
    ```
 
 2. [ ] Create Temporal client adapter

--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@
 
 ## Install
 
+Pick the backend you want to use:
+
 ```shell
+# Celery based execution
+pip install dj-triggers[celery]
+
+# Temporal based execution
+pip install dj-triggers[temporal]
+
+# Or install the base package if you'll run triggers manually
 pip install dj-triggers
 ```
 
@@ -23,7 +32,8 @@ INSTALLED_APPS = [
 
 ### Prerequisites
 
-Celery is required to be setup in your project.
+Set up the backend you installed. Configure Celery or Temporal, or provide your
+own mechanism for running `triggers.tasks.handle_event`.
 
 ## Quickstart
 
@@ -171,15 +181,10 @@ Starting with version 1.1.0, django-triggers supports using [Temporal](https://t
 
 ### Setup
 
-1. Install the required dependencies:
+1. Install the Temporal dependencies:
 
 ```shell
-# Using uv
-uv add temporalio asgiref
-uv sync
-
-# Or with pip
-pip install temporalio asgiref
+pip install dj-triggers[temporal]
 ```
 
 2. Enable Temporal integration in your Django settings:

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,15 +11,10 @@ brew install temporal
 temporal server start-dev
 ```
 
-2. Install the required dependencies:
+2. Install the Temporal dependencies:
 
 ```sh
-# Using uv
-uv add temporalio asgiref
-uv sync
-
-# Or with pip
-pip install temporalio asgiref
+pip install dj-triggers[temporal]
 ```
 
 3. Configure the integration in your Django settings:

--- a/examples/run_temporal_worker.py
+++ b/examples/run_temporal_worker.py
@@ -7,7 +7,7 @@ for the django-triggers system.
 
 To run this script:
 1. Make sure you have a Temporal server running (see README.md)
-2. Install the dependencies: `uv add temporalio asgiref`
+2. Install the dependencies: `pip install dj-triggers[temporal]`
 3. Set DJANGO_SETTINGS_MODULE to point to your Django settings
 4. Run this script: `python examples/run_temporal_worker.py`
 """

--- a/examples/test_temporal_integration.py
+++ b/examples/test_temporal_integration.py
@@ -9,7 +9,7 @@ This script demonstrates:
 
 To run this example:
 1. Make sure you have a Temporal server running (see README.md)
-2. Install the dependencies: `uv add temporalio asgiref`
+2. Install the dependencies: `pip install dj-triggers[temporal]`
 3. Set DJANGO_SETTINGS_MODULE to point to your Django settings
 4. Run this script: `python examples/test_temporal_integration.py`
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,12 @@ classifiers = [
 dependencies = [
     "Django>=3",
     "django-polymorphic>=3,<4",
-    "celery>=4.4",
     "django-more-admin-filters>=1.7",
+]
+
+[project.optional-dependencies]
+celery = ["celery>=4.4"]
+temporal = [
     "temporalio>=1.11.1",
     "asgiref>=3.6.0",
 ]

--- a/triggers/apps.py
+++ b/triggers/apps.py
@@ -7,5 +7,10 @@ class DefaultConfig(AppConfig):
     verbose_name = _("Triggers")
 
     def ready(self):
-        # Connect `triggers.tasks.on_event_fired` to `Event.fired` signal
-        from triggers import tasks  # noqa: F401
+        # Connect `triggers.tasks.on_event_fired` to `Event.fired` signal if
+        # Celery is available. This allows using alternative backends like
+        # Temporal or handling triggers manually without Celery installed.
+        try:
+            from triggers import tasks  # noqa: F401
+        except Exception:  # pragma: no cover - optional dependency
+            pass


### PR DESCRIPTION
## Summary
- make Celery import optional so the app can load without it
- move Celery and Temporal deps to optional extras
- describe installing optional backends in README
- update Temporal instructions in examples and tasks

## Testing
- `uv run ruff check` *(fails: Failed to fetch)*
- `uv run mypy triggers tests` *(fails: Failed to fetch)*
- `uv run pytest -q` *(fails: Failed to fetch)*